### PR TITLE
Fix type for copyright and auto get year

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -94,7 +94,7 @@ const Footer = ({data, ...props}) => {
           <styles.ContentSection width={'60%'} padding={true}>
             <styles.SectionTitle>Copyright</styles.SectionTitle>
 
-            <styles.Type>&copy; Copright 2020 MMK Public Speaking</styles.Type>
+            <styles.Type>&copy; Copyright {new Date().getFullYear()} MMK Public Speaking</styles.Type>
           </styles.ContentSection>
           
             <styles.FooterDivider onlyMobile />


### PR DESCRIPTION
Fixes #1 
- Typo 'copright' fixed
- Get's current year